### PR TITLE
Add functionality for extending native elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,15 @@ step with a packager, you can import it directly into a web page:
 
 ```javascript
 import { app, h, text } from 'hyperapp';
-import { define } from 'hyperapp-custom-element';
+import { generateClass } from 'hyperapp-custom-element';
 
-define({
-  // The tag name of the CustomElement.
-  name: 'my-counter',
-
+const MyCustomElement = generateClass({
   // The library uses your imported version of Hyperapp.
   app: app,
 
-  // The initial state of the component.
-  state: { theThing: 'Nothing' },
+  // The initial state of the component. It can be a state object, or anything
+  // dispatchable by Hyperapp.
+  init: { theThing: 'Nothing' },
 
   // The Hyperapp View function that builds the component's DOM.
   view: (state) => {
@@ -122,6 +120,48 @@ define({
   // Whether to use Shadow DOM (true) or Light DOM (false).
   useShadowDOM: true,
 });
+
+// Register the class and its tag name.
+customElements.define('my-tag', MyCustomElement);
+```
+
+### Extending Native Elements
+
+```javascript
+import { app, h, text } from 'hyperapp';
+import { generateClass } from 'hyperapp-custom-element';
+
+const MyExtendedElement = generateClass({
+  app,
+
+  // The initial state of the component.
+  init: { theThing: 'Nothing' },
+
+  // With an extended native element no DOM will be built. However, Hyperapp
+  // needs to have a view function, so provide something minimal. It will not
+  // be added to the DOM, though.
+  view: (state) => {
+    h('span', {});
+  },
+
+  subscriptions: [],
+
+  // When extending a native element, specify here only the properties,
+  // attributes and methods that are being *added* -- not those that the native
+  // element already has.
+  exposedConfig: [],
+
+  exposedMethods: {},
+
+  // When extending a native element, this needs to be false.
+  useShadowDOM: false,
+});
+
+// Register the class, its tag name, and the element that is being extended.
+// Note the additional options object, that tells the browser which tag we are
+// extending. This is necessary because some tags share the same HTMLElement
+// class.
+customElements.define('extended-tag', MyExtendedElement, { extends: 'input' });
 ```
 
 ### Dispatching Events
@@ -156,6 +196,7 @@ function DoSomething(state, props) {
 
 ## Example
 
-- A full example component: [my-counter.js](./examples/counter/my-counter.js)
-- A web page that consumes and exercises this component:
-  [counter.html](./examples/counter/counter.html)
+- Counter component:
+  - A full example component: [my-counter.js](./examples/counter/my-counter.js)
+  - A web page that consumes and exercises this component:
+    [counter.html](./examples/counter/counter.html)

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 import { terser } from 'rollup-plugin-terser';
 
 export default {
-  input: './src/custom-element.js',
+  input: './src/index.js',
   output: {
     file: './dist/custom-element.min.js',
     format: 'es',

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -22,8 +22,8 @@ export { generateClass, define, dispatchEventEffect };
  *
  * @param {Object} config
  * @param {function} config.app Hyperapp's app() function.
- * @param {Object} config.state An object containing the component's default
- *      state.
+ * @param {Object} config.init The initial state, or an Action that will return
+ *      the initial state (and possibly an effect too).
  * @param {Hyperapp.View} config.view Hyperapp view function that composes the
  *      component's DOM structure.
  * @param {Hyperapp.Subscriptions} config.subscriptions Hyperapp subscriptions
@@ -60,7 +60,8 @@ export { generateClass, define, dispatchEventEffect };
  */
 function generateClass({
   app,
-  state,
+  state, // Deprecated. Use init instead.
+  init,
   view,
   subscriptions,
   exposedConfig = [],
@@ -134,13 +135,14 @@ function generateClass({
       // it is given to start with.
       const span = root.appendChild(document.createElement('span'));
 
-      // Record the initial state.
-      this._state = state;
-
       // Create a Hyperapp instance, which will render the view in the
       // shadow DOM or a DocumentFragment.
+      if (state) {
+        init = state;
+        console.warn('Passing "state" is deprecated. Pass "init" instead');
+      }
       app({
-        init: state,
+        init,
         view,
         subscriptions,
         middleware: this.wrapDispatch.bind(this),

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1,4 +1,6 @@
-export { generateClass, define, dispatchEventEffect };
+import { setOnEventListenerEffect } from './effects';
+
+export { generateClass, define };
 
 /**
  * Creates a CustomElement class definition that uses the Hyperapp
@@ -473,31 +475,6 @@ function generateClass({
   }
 
   /**
-   * Hyperapp Effect for handling changes to a component's on<event> HTML
-   * attribute.
-   * If the attribute value is being changed, registers the new value (must be a
-   * function) as an event listener, and de-registers the old value's listener.
-   * If the attribute was removed, de-registers the listener.
-   *
-   * @param {function} _ The dispatch function passed by Hyperapp. Not used here.
-   * @param {Object} props
-   * @param {string} props.eventType The application-defined event type.
-   * @param {function|undefined|null} props.oldVal The previous value of the
-   *    on<event> attribute
-   * @param {function|null} props.newVal The new value of the on<event> attribute.
-   */
-  function setOnEventListenerEffect(_, { eventType, oldVal, newVal }) {
-    // Make the function an event listener.
-    // But first, remove the current one if there is one.
-    if (oldVal !== null) {
-      this.removeEventListener(eventType, oldVal);
-    }
-    if (newVal !== null) {
-      this.addEventListener(eventType, newVal);
-    }
-  }
-
-  /**
    * Generates the specified properties and adds them to the CustomElement's
    * class definition.
    */
@@ -547,23 +524,4 @@ function define(name, cfg) {
   const cls = generateClass(cfg);
 
   customElements.define(name, cls);
-}
-
-/**
- * Hyperapp Effect that dispatches a CustomEvent for the consuming app to
- * consume.
- *
- * @param {function} _ The dispatch function passed by Hyperapp. Not used here.
- * @param {Object} props
- * @param {string} props.eventType The name of the event. Corresponds to typeArg
- *    in the CustomEvent constructor.
- * @param {CustomEventInit} props.eventInit Settings for the custom event. Corr-
- *    esponds to customEventInit in the CustomEvent constructor.
- * @see https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
- */
-function dispatchEventEffect(_, { eventType, eventInit }) {
-  const ev = new CustomEvent(eventType, eventInit);
-  const cancel = !this.dispatchEvent(ev);
-  // TODO: figure out how to supply useful functionality for cancelling default
-  // actions.
 }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1,6 +1,6 @@
-import { setOnEventListenerEffect } from './effects';
-
 export { generateClass, define };
+
+import { setOnEventListenerEffect } from './effects';
 
 /**
  * Creates a CustomElement class definition that uses the Hyperapp

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,0 +1,45 @@
+export { dispatchEventEffect, setOnEventListenerEffect };
+
+/**
+ * Hyperapp Effect that dispatches a CustomEvent for the consuming app to
+ * consume.
+ *
+ * @param {function} _ The dispatch function passed by Hyperapp. Not used here.
+ * @param {Object} props
+ * @param {string} props.eventType The name of the event. Corresponds to typeArg
+ *    in the CustomEvent constructor.
+ * @param {CustomEventInit} props.eventInit Settings for the custom event. Corr-
+ *    esponds to customEventInit in the CustomEvent constructor.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
+ */
+function dispatchEventEffect(_, { eventType, eventInit }) {
+  const ev = new CustomEvent(eventType, eventInit);
+  const cancel = !this.dispatchEvent(ev);
+  // TODO: figure out how to supply useful functionality for cancelling default
+  // actions.
+}
+
+/**
+ * Hyperapp Effect for handling changes to a component's on<event> HTML
+ * attribute.
+ * If the attribute value is being changed, registers the new value (must be a
+ * function) as an event listener, and de-registers the old value's listener.
+ * If the attribute was removed, de-registers the listener.
+ *
+ * @param {function} _ The dispatch function passed by Hyperapp. Not used here.
+ * @param {Object} props
+ * @param {string} props.eventType The application-defined event type.
+ * @param {function|undefined|null} props.oldVal The previous value of the
+ *    on<event> attribute
+ * @param {function|null} props.newVal The new value of the on<event> attribute.
+ */
+function setOnEventListenerEffect(_, { eventType, oldVal, newVal }) {
+  // Make the function an event listener.
+  // But first, remove the current one if there is one.
+  if (oldVal !== null) {
+    this.removeEventListener(eventType, oldVal);
+  }
+  if (newVal !== null) {
+    this.addEventListener(eventType, newVal);
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+export { generateClass, define } from './custom-element';
+export { dispatchEventEffect } from './effects';


### PR DESCRIPTION
- Instead of `define(...)`, call `generateClass(...)`. The consumer is now responsible for registration of the class using `customElements.define(...)`.
- In `generateClass(...)`'s agrument object, rename `state` property to `init` and accept any value that Hyperapp can dispatch.
- Sync all relevant properties to attributes whenever the state changes, not just when a property setter action is invoked.
- Improve the way on\<event\> handlers are set.
- Reflect the changes in the readme.