### PR TITLE
Add middleware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,13 @@ const MyCustomElement = generateClass({
   // The Hyperapp View function that builds the component's DOM.
   view: (state) => h('p', {}, text(`The thing is: ${state.theThing}`)),
 
-  // An array of Hyperapp subscriptions (optional).
-  subscriptions: [],
+  // A function that returns an array of Hyperapp subscriptions (optional).
+  subscriptions: getSubscriptions,
+
+  // A middleware function (optional).
+  // N.B.: This library defines its own middleware. If middleware is supplied
+  // here, it will be wrapped by the library's own middleware.
+  middleware: middleware,
 
   // An array of Javascript properties and HTML attributes (they often come in
   // pairs) that can be used by a consuming app to configure the component.
@@ -143,7 +148,9 @@ const MyExtendedElement = generateClass({
   // be added to the DOM, though.
   view: (state) => h('span', {}),
 
-  subscriptions: [],
+  subscriptions: getSubscriptions,
+
+  middleware: middleware,
 
   // When extending a native element, specify here only the properties,
   // attributes and methods that are being *added* -- not those that the native

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,5 +7,5 @@ export default {
     format: 'es',
     sourcemap: true,
   },
-  plugins: [terser()],
+  plugins: [terser({ keep_fnames: /Effect$|^[A-Z]/ })],
 };

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -210,6 +210,24 @@ function generateClass({
      * @returns {function} a modified dispatch function
      */
     wrapDispatch(dispatch) {
+      /**
+       * Binds an action to this element.
+       * When used in conjunction with additional middleware that wraps actions
+       * and effects, it copies the $isWrapped indicator from the unbound
+       * function to the bound function. This can be used by the middleware to
+       * prevent rewrapping wrapped functions.
+       *
+       * @param {Hyperapp.Action} action
+       */
+      const bindToThis = (action) => {
+        const bound = action.bind(this);
+        const isWrapped = action['$isWrapped'];
+        if (isWrapped) {
+          bound['$isWrapped'] = true;
+        }
+        return bound;
+      };
+
       const newDispatch = (action, props) => {
         // In order to bind the Actions to the component, we need to identify
         // the actions in the various signatures of the dispatch function.
@@ -230,18 +248,18 @@ function generateClass({
         let newState;
         if (typeof action === 'function') {
           // Signature 1.
-          action = action.bind(this);
+          action = bindToThis(action);
         } else if (Array.isArray(action)) {
           if (typeof action[0] === 'function') {
             // Signature 2: the first element of the array is an action.
-            action[0] = action[0].bind(this);
+            action[0] = bindToThis(action[0]);
           } else {
             // Signature 3: the first element of the array is a new state.
             newState = action[0];
             // The remaining elements are Effect tuples.
             for (let i = 1; i < action.length; i++) {
               const tuple = action[i];
-              tuple[0] = tuple[0].bind(this);
+              tuple[0] = bindToThis(tuple[0]);
             }
           }
         } else {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -488,6 +488,8 @@ function generateClass({
       // value will be a function.
       if (handler && typeof handler !== 'function') {
         handler = new Function('event', handler);
+        // Assign the function a name for logging purposes.
+        Object.defineProperty(handler, 'name', { value: name });
       }
 
       // We need to know the previous value, so we can remove it as a listener.

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,5 @@
+export function combineMiddleware(outer, inner) {
+  return function middleware(dispatch) {
+    return outer(inner(dispatch));
+  };
+}

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,3 +1,12 @@
+/**
+ * Returns a Hyperapp middleware function (wrapper for dispatch) that combines
+ * two other middleware functions. The outer function will be the first to be
+ * called by Hyperapp, so it has the first opportunity to make changes.
+ *
+ * @param {function} outer
+ * @param {function} inner
+ * @returns {function}
+ */
 export function combineMiddleware(outer, inner) {
   return function middleware(dispatch) {
     return outer(inner(dispatch));


### PR DESCRIPTION
Support Hyperapp's middleware feature. The wrinkle with this is that the custom element uses its own middleware, so they have to be combined.