### PR TITLE
Fix documentation: middleware->dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,11 @@ const MyCustomElement = generateClass({
   // A function that returns an array of Hyperapp subscriptions (optional).
   subscriptions: getSubscriptions,
 
-  // A middleware function (optional).
-  // N.B.: This library defines its own middleware. If middleware is supplied
-  // here, it will be wrapped by the library's own middleware.
-  middleware: middleware,
+  // A dispatch initialiser function (optional).
+  // N.B.: This library defines its own dispatch function. If a dispatch
+  // initialiser is supplied here, it will be combined with the library's own
+  // function.
+  dispatch: dispatch,
 
   // An array of Javascript properties and HTML attributes (they often come in
   // pairs) that can be used by a consuming app to configure the component.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ const MyExtendedElement = generateClass({
 
   subscriptions: getSubscriptions,
 
-  middleware: middleware,
+  dispatch: dispatch,
 
   // When extending a native element, specify here only the properties,
   // attributes and methods that are being *added* -- not those that the native


### PR DESCRIPTION
In the readme, correct the `middleware` reference to `dispatch`. This should have been in PR #6