### PR TITLE
Miscellaneous tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ const MyCustomElement = generateClass({
   ],
 
   // Methods to expose to the consuming app, and the corresponding Actions that
-  // will be invoked when the methods are called.
+  // will be invoked when the methods are called. Just as the underlying Action
+  // it dispatches, a method can be called with a single payload argument.
   exposedMethods: {
     doIt: DoSomething,
   },

--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ customElements.define('extended-tag', MyExtendedElement, { extends: 'input' });
 ### Dispatching Events
 
 If your component has 'on\<event\>' attributes and/or dispatches events, you can
-use the convenient `dispatchEventEffect` effect that is exported by the module.
-This effect should receive a properties object with an `eventType` property and
-an `eventInit` property, which correspond to arguments of the [CustomEvent
+use the convenient `dispatchEvent` effect generator function that is exported by
+the module. This function should receive these two arguments: `eventType` and
+`eventInit`, which correspond to arguments of the [CustomEvent
 constructor](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent),
 `typeArg` and `customEventInit`.
 
@@ -189,13 +189,7 @@ function DoSomething(state, props) {
     ...props,
   };
 
-  const effect = [
-    dispatchEventEffect,
-    {
-      eventType: 'DidSomething',
-      eventInit: { bubbles: true },
-    },
-  ];
+  const effect = dispatchEvent('DidSomething', { detail: 3 });
 
   return [newState, effect];
 }

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ constructor](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/Custom
 `typeArg` and `customEventInit`.
 
 ```javascript
-import { dispatchEventEffect } from 'hyperapp-custom-element';
+import { dispatchEvent } from 'hyperapp-custom-element';
 
 function DoSomething(state, props) {
   const newState = {

--- a/examples/counter/my-counter.js
+++ b/examples/counter/my-counter.js
@@ -1,7 +1,7 @@
 import { h, text, app } from 'https://unpkg.com/hyperapp';
 import {
   generateClass,
-  dispatchEventEffect,
+  dispatchEvent,
 } from 'https://unpkg.com/hyperapp-custom-element';
 
 /**
@@ -98,14 +98,5 @@ function IncrementCounter(state, event) {
     count: state.count + state.incrementSize,
   };
 
-  return [
-    newState,
-    [
-      dispatchEventEffect,
-      {
-        eventType: 'Incremented',
-        eventInit: { bubbles: true },
-      },
-    ],
-  ];
+  return [newState, dispatchEvent('Incremented', { bubbles: true })];
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,5 +7,5 @@ export default {
     format: 'es',
     sourcemap: true,
   },
-  plugins: [terser({ keep_fnames: /Effect$|^[A-Z]/ })],
+  plugins: [terser({ keep_fnames: /EffectRunner$|^[A-Z]/ })],
 };

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -141,8 +141,12 @@ function generateClass({
 
       // Before creating component's DOM, we need a trivial node that Hyperapp
       // can replace, such as <span>. Hyperapp always _replaces_ the node that
-      // it is given to start with.
-      const span = root.appendChild(document.createElement('span'));
+      // it is given to start with. However, if no `view` function is provided,
+      // i.e. the component has no visual UI, there is no root node, so it is
+      // unnecessary to create a `span` element.
+      const span = view
+        ? root.appendChild(document.createElement('span'))
+        : undefined;
 
       // Configure our dispatch initialiser.
       const wrappedDispatch = this.wrapDispatch.bind(this);

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1,6 +1,6 @@
 export { generateClass };
 
-import { setOnEventListenerEffect } from './effects';
+import { setOnEventListenerEffectRunner } from './effects';
 import { combineDispatchInitialisers } from './middleware';
 
 /**
@@ -519,7 +519,7 @@ function generateClass({
 
       // Configure an effect that will register the handler as a listener.
       const effect = [
-        setOnEventListenerEffect,
+        setOnEventListenerEffectRunner,
         { eventType, oldVal: oldHandler, newVal: handler },
       ];
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -554,8 +554,8 @@ function generateClass({
    */
   (function addMethods() {
     for (const name in exposedMethods) {
-      CustomElement.prototype[name] = function () {
-        this.dispatchAction(exposedMethods[name]);
+      CustomElement.prototype[name] = function (payload) {
+        this.dispatchAction(exposedMethods[name], payload);
       };
     }
   })();

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,7 +1,25 @@
-export { dispatchEventEffect, setOnEventListenerEffect };
+export {
+  dispatchEvent,
+  dispatchEventEffectRunner as dispatchEventEffect, // deprecated
+  setOnEventListenerEffectRunner,
+};
 
 /**
- * Hyperapp Effect that dispatches a CustomEvent for the consuming app to
+ * Returns a Hyperapp Effect tuple that dispatches a CustomEvent for the
+ * consuming app to consume.
+ *
+ * @param {string} eventType The name of the event. Corresponds to typeArg in
+ *    the CustomEvent constructor.
+ * @param {CustomEventInit} [eventInit] Settings for the custom event. Corres-
+ *    ponds to customEventInit in the CustomEvent constructor. Optional.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
+ */
+function dispatchEvent(eventType, eventInit) {
+  return [dispatchEventEffectRunner, { eventType, eventInit }];
+}
+
+/**
+ * Hyperapp Effecter that dispatches a CustomEvent for the consuming app to
  * consume.
  *
  * @param {function} _ The dispatch function passed by Hyperapp. Not used here.
@@ -12,7 +30,7 @@ export { dispatchEventEffect, setOnEventListenerEffect };
  *    esponds to customEventInit in the CustomEvent constructor.
  * @see https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
  */
-function dispatchEventEffect(_, { eventType, eventInit }) {
+function dispatchEventEffectRunner(_, { eventType, eventInit }) {
   const ev = new CustomEvent(eventType, eventInit);
   const cancel = !this.dispatchEvent(ev);
   // TODO: figure out how to supply useful functionality for cancelling default
@@ -20,7 +38,7 @@ function dispatchEventEffect(_, { eventType, eventInit }) {
 }
 
 /**
- * Hyperapp Effect for handling changes to a component's on<event> HTML
+ * Hyperapp Effect runner for handling changes to a component's on<event> HTML
  * attribute.
  * If the attribute value is being changed, registers the new value (must be a
  * function) as an event listener, and de-registers the old value's listener.
@@ -33,7 +51,7 @@ function dispatchEventEffect(_, { eventType, eventInit }) {
  *    on<event> attribute
  * @param {function|null} props.newVal The new value of the on<event> attribute.
  */
-function setOnEventListenerEffect(_, { eventType, oldVal, newVal }) {
+function setOnEventListenerEffectRunner(_, { eventType, oldVal, newVal }) {
   // Make the function an event listener.
   // But first, remove the current one if there is one.
   if (oldVal !== null) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
 export { generateClass } from './custom-element';
-export { dispatchEvent } from './effects';
+export { dispatchEvent, dispatchEventEffect } from './effects';

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
 export { generateClass } from './custom-element';
-export { dispatchEventEffect } from './effects';
+export { dispatchEvent } from './effects';


### PR DESCRIPTION
- Exposed methods can now be called with payload arguments.
- `dispatchEventEffect` (Hyperapp _effect runner_) is deprecated in favour of `dispatchEvent`, which is a convenience method that returns a Hyperapp _effect_ tuple.
- If no `view` function is provided, an empty `<span>` is no longer created.
